### PR TITLE
Fix mobile cursor size

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,8 +355,8 @@ ul li::before {
     width: 96px;
     height: 96px;
   }
-}
-.cursor {
-  font-size: 1.8rem;
+  .cursor {
+    font-size: 1.8rem;
+  }
 }
 


### PR DESCRIPTION
## Summary
- fix cursor font-size so desktop style isn't overridden

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684015b851788324b553ac7efe0d72aa